### PR TITLE
Closes-Bug: 1446427 - On selecting all rows, browser hangs and grid is f...

### DIFF
--- a/webroot/css/contrail.custom.css
+++ b/webroot/css/contrail.custom.css
@@ -1033,7 +1033,7 @@ a.selectAllLink:hover {
 	color: #393939;
 	font-size: 13px;
 	padding: 5px;
-	overflow-y: auto;
+    overflow-y: hidden;
 	word-break:break-all;
 	white-space: normal;
 }
@@ -1041,7 +1041,12 @@ a.selectAllLink:hover {
 	color: #3182bd;
 	cursor: pointer;
 }
-
+.slick-cell.fixed-row-height {
+    overflow-y: hidden;
+    word-break: normal;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
 .grid-footer{
 	width:100%;
 	height:22px;	

--- a/webroot/css/contrail.layout.css
+++ b/webroot/css/contrail.layout.css
@@ -2364,6 +2364,18 @@ button.btn:active {
 .padding-top-5{padding-top:5px !important;}
 
 /* height framework */
+.height-20 {height: 20px !important;}
+.height-30 {height: 30px !important;}
+.height-40 {height: 40px !important;}
+.height-50 {height: 50px !important;}
+.height-60 {height: 60px !important;}
+.height-70 {height: 70px !important;}
+.height-80 {height: 80px !important;}
+.height-90 {height: 90px !important;}
+.height-100 {height: 100px !important;}
+.height-110 {height: 110px !important;}
+.height-120 {height: 120px !important;}
+.height-130 {height: 130px !important;}
 .height-200 {height:200px !important;}
 .height-250 {height:250px !important;}
 .height-300 {height:300px !important;}

--- a/webroot/js/slickgrid-utils.js
+++ b/webroot/js/slickgrid-utils.js
@@ -36,6 +36,7 @@ function getDefaultGridConfig() {
                 fullWidthRows: true,
                 multiColumnSort: true,
                 rowHeight: 30,
+                fixedRowHeight: false,
                 gridHeight: 500,
                 rowSelectable: false,
                 sortable: true,
@@ -68,7 +69,7 @@ function getDefaultGridConfig() {
             pager : {
                 options : {
                     pageSize : 50,
-                    pageSizeSelect : [10, 50, 100, 200, 500 ]
+                    pageSizeSelect : [10, 50, 100, 200]
                 }
             }
         }
@@ -89,9 +90,10 @@ function getDefaultGridConfig() {
         	autoRefreshInterval = false, searchColumns = [],
             currentSelectedRows = [],
             remoteConfig = {}, ajaxConfig,
-            dvConfig = null, gridContainer = this, 
-            eventHandlerMap = {grid: {}, dataView: {}}, 
-            scrolledStatus = {scrollLeft: 0, scrollTop: 0};
+            dvConfig = null, gridContainer = this,
+            eventHandlerMap = {grid: {}, dataView: {}},
+            scrolledStatus = {scrollLeft: 0, scrollTop: 0},
+            adjustAllRowHeightTimer = null;
 
         // Extending the params with default settings
         $.extend(true, gridConfig, defaultGridConfig, customGridConfig);
@@ -103,6 +105,10 @@ function getDefaultGridConfig() {
 
         if(contrail.checkIfKeyExistInObject(true, customGridConfig, 'footer.pager.options.pageSizeSelect')) {
             gridConfig.footer.pager.options.pageSizeSelect = customGridConfig.footer.pager.options.pageSizeSelect;
+        }
+
+        if (gridOptions.fixedRowHeight != false && _.isNumber(gridOptions.fixedRowHeight)) {
+            gridOptions.rowHeight = gridOptions.fixedRowHeight;
         }
 
         //Local Datasource means the client-side data with client-side pagination if footer initialized
@@ -225,7 +231,7 @@ function getDefaultGridConfig() {
             	return returnFlag;
         	}
         };
-        
+
         function startAutoRefresh(refreshPeriod){
             if(refreshPeriod && !autoRefreshInterval){
 	        	autoRefreshInterval = setInterval(function(){
@@ -344,6 +350,10 @@ function getDefaultGridConfig() {
                     if(!contrail.checkIfExist(val.tooltip)) {
                         val.toolTip = val.name;
                     }
+                    if (gridOptions.fixedRowHeight != false && _.isNumber(gridOptions.fixedRowHeight)) {
+                        val.cssClass = (contrail.checkIfExist(val.cssClass) ? val.cssClass + ' ' : '') +
+                        'fixed-row-height height-' + (gridOptions.fixedRowHeight - 10);
+                    }
                 });
             }
 
@@ -419,15 +429,15 @@ function getDefaultGridConfig() {
 	            			onClick: function(e,dc){
 	            				var target = e.target;
                                 if($(target).hasClass('icon-caret-right')){
-                                	
+
                                 	if(!$(target).parents('.slick-row-master').next().hasClass('slick-row-detail')){
 	                                	var cellSpaceColumn = 0,
 	                                    	cellSpaceRow = gridColumns.length - 1;
-	
+
 	                                    //if (gridOptions.checkboxSelectable != false) {
 	                                    //    cellSpaceColumn++;
 	                                    //}
-	
+
 	                                    $(target).parents('.slick-row-master').after(' \
 	            	            				<div class="ui-widget-content slick-row slick-row-detail" data-cgrid="' + $(target).parents('.slick-row-master').data('cgrid') + '"> \
 	            	            					<div class="slick-cell l' + cellSpaceColumn + ' r' + cellSpaceRow + '"> \
@@ -436,9 +446,9 @@ function getDefaultGridConfig() {
 	            	            						</div> \
 	            	            					</div> \
 	            	            				</div>');
-	
+
 	                                    $(target).parents('.slick-row-master').next('.slick-row-detail').find('.slick-row-detail-container').show();
-	                                    
+
 	                                    // onInit called after building a template
 	                                	if(contrail.checkIfFunction(gridOptions.detail.onInit)){
 	                                		e['detailRow'] = $(target).parents('.slick-row-master').next().find('.slick-row-detail-container');
@@ -449,7 +459,7 @@ function getDefaultGridConfig() {
                                 	else{
                                 		$(target).parents('.slick-row-master').next('.slick-row-detail').show();
                                 	}
-                                	
+
                                     if(contrail.checkIfFunction(gridOptions.detail.onExpand)){
                                     	gridOptions.detail.onExpand(e,dc);
                                     }
@@ -465,7 +475,7 @@ function getDefaultGridConfig() {
                                 }
                                 else if($(target).hasClass('icon-caret-down')){
                                     $(target).parents('.slick-row-master').next('.slick-row-detail').hide();
-                                    
+
                                     if(contrail.checkIfFunction(gridOptions.detail.onCollapse)){
                                     	gridOptions.detail.onCollapse(e,dc);
                                     }
@@ -476,7 +486,7 @@ function getDefaultGridConfig() {
 	                });
 	                columns = columns.concat(gridColumns);
 	                gridColumns = columns;
-	                
+
 	                gridContainer.find('.slick-row-detail').live('click', function(){
 	                	var rowId = $(this).data('cgrid');
 	                	setTimeout(function(){
@@ -552,7 +562,7 @@ function getDefaultGridConfig() {
                 }
         	}
         };
-        
+
         function refreshDetailTemplateById(id){
         	var source = gridOptions.detail.template,
                 templateKey = gridContainer.prop('id') + '-grid-detail-template';
@@ -574,9 +584,9 @@ function getDefaultGridConfig() {
             	gridContainer.find('.slick-row-detail-template-' + id).parents('.slick-row-detail').remove();
             }
         }
-        
+
         function initGridEvents() {
-        	
+
         	eventHandlerMap.grid['onScroll'] = function(e, args){
         		if(scrolledStatus.scrollLeft != args.scrollLeft || scrolledStatus.scrollTop != args.scrollTop){
                 	gridContainer.data('contrailGrid').adjustAllRowHeight();
@@ -584,7 +594,7 @@ function getDefaultGridConfig() {
                 	scrolledStatus.scrollTop = args.scrollTop;
             	}
         	};
-        	
+
         	grid['onScroll'].subscribe(eventHandlerMap.grid['onScroll']);
 
             eventHandlerMap.grid['onSelectedRowsChanged'] = function(e, args){
@@ -592,16 +602,17 @@ function getDefaultGridConfig() {
                     onSomethingChecked = contrail.checkIfFunction(gridOptions.checkboxSelectable.onSomethingChecked) ? gridOptions.checkboxSelectable.onSomethingChecked : null,
                     onEverythingChecked = contrail.checkIfFunction(gridOptions.checkboxSelectable.onEverythingChecked) ? gridOptions.checkboxSelectable.onEverythingChecked : null;
 
-                var selectedRowLength = grid.getSelectedRows().length;
+                var selectedRowLength = args.rows.length;
 
                 if (selectedRowLength == 0) {
                     (contrail.checkIfExist(onNothingChecked) ? onNothingChecked(e) : '');
                 }
-                if (selectedRowLength > 0) {
+                else {
                     (contrail.checkIfExist(onSomethingChecked) ? onSomethingChecked(e) : '');
-                }
-                if (selectedRowLength == grid.getDataLength()) {
-                    (contrail.checkIfExist(onEverythingChecked) ? onEverythingChecked(e) : '');
+
+                    if (selectedRowLength == grid.getDataLength()) {
+                        (contrail.checkIfExist(onEverythingChecked) ? onEverythingChecked(e) : '');
+                    }
                 }
 
                 gridContainer.data('contrailGrid').refreshView();
@@ -727,9 +738,9 @@ function getDefaultGridConfig() {
                     }
                 }
             };
-            
+
             grid['onClick'].subscribe(eventHandlerMap.grid['onClick']);
- 
+
         };
 
         function initOnClickDocument(containerIdentifier, callback) {
@@ -739,50 +750,52 @@ function getDefaultGridConfig() {
    			    }
     		});
         };
-        
+
         function initDataView() {
             eventHandlerMap.dataView['onDataUpdate'] = function(e, args) {
-                //Refresh the grid only if it's not destroyed
-                if($(gridContainer).data('contrailGrid') != null && (args.previous != args.current || args.rows.length > 0)) {
-                    grid.invalidateAllRows();
-                    grid.updateRowCount();
-                    grid.render();
+                setTimeout(function() {
+                    //Refresh the grid only if it's not destroyed
+                    if($(gridContainer).data('contrailGrid') != null && (args.previous != args.current || args.rows.length > 0)) {
+                        grid.invalidateAllRows();
+                        grid.updateRowCount();
+                        grid.render();
 
-                    //onRowCount Changed
-                    if (args.previous != args.current) {
-                        gridContainer.data('contrailGrid').removeGridMessage();
-                        if(dataView.getLength() == 0){
-                            emptyGridHandler();
-                            gridContainer.find('.slick-row-detail').remove();
-                        } else {
-                            gridContainer.find('.grid-footer').removeClass('hide');
-                            onDataGridHandler();
-                        }
-                    }
-
-                    //onRows Changed
-                    if (args.rows.length > 0) {
-                        if(contrail.checkIfFunction(gridDataSource.events.onDataBoundCB)) {
-                            gridDataSource.events.onDataBoundCB();
+                        //onRowCount Changed
+                        if (args.previous != args.current) {
+                            gridContainer.data('contrailGrid').removeGridMessage();
+                            if(dataView.getLength() == 0){
+                                emptyGridHandler();
+                                gridContainer.find('.slick-row-detail').remove();
+                            } else {
+                                gridContainer.find('.grid-footer').removeClass('hide');
+                                onDataGridHandler();
+                            }
                         }
 
-                        // Adjusting the row height for all rows
-                        gridContainer.data('contrailGrid').adjustAllRowHeight();
+                        //onRows Changed
+                        if (args.rows.length > 0) {
+                            if(contrail.checkIfFunction(gridDataSource.events.onDataBoundCB)) {
+                                gridDataSource.events.onDataBoundCB();
+                            }
 
-                        // Assigning odd and even classes to take care of coloring effect on alternate rows
-                        gridContainer.data('contrailGrid').adjustGridAlternateColors();
+                            // Adjusting the row height for all rows
+                            gridContainer.data('contrailGrid').adjustAllRowHeight();
 
-                        // Refreshing the detail view
-                        gridContainer.data('contrailGrid').refreshDetailView();
+                            // Assigning odd and even classes to take care of coloring effect on alternate rows
+                            gridContainer.data('contrailGrid').adjustGridAlternateColors();
+
+                            // Refreshing the detail view
+                            gridContainer.data('contrailGrid').refreshDetailView();
+                        }
+
+                        if(contrail.checkIfFunction(gridDataSource.events.onDataUpdateCB)) {
+                            gridDataSource.events.onDataUpdateCB(e, args);
+                        }
+                    } else if (dataView.getLength() == 0){
+                        emptyGridHandler();
+                        gridContainer.find('.slick-row-detail').remove();
                     }
-
-                    if(contrail.checkIfFunction(gridDataSource.events.onDataUpdateCB)) {
-                        gridDataSource.events.onDataUpdateCB(e, args);
-                    }
-                } else if (dataView.getLength() == 0){
-                    emptyGridHandler();
-                    gridContainer.find('.slick-row-detail').remove();
-                }
+                }, 0);
             };
 
             $.each(eventHandlerMap.dataView, function(key, val){
@@ -795,9 +808,9 @@ function getDefaultGridConfig() {
                 performSort(args.sortCols);
                 grid.setSelectedRows([]);
         	};
-        	
+
         	grid['onSort'].subscribe(eventHandlerMap.grid['onSort']);
-        	
+
             initSearchBox();
         };
 
@@ -840,9 +853,9 @@ function getDefaultGridConfig() {
                         gridContainer.find('.input-searchbox input').focus();
                     }
                 },300);
-            	
+
             });
-            
+
             initOnClickDocument('.input-searchbox',function(e){
         	    if(gridContainer.find('.input-searchbox').is(":visible") && gridContainer.find('.input-searchbox').find('input').val() == '') {
                 	gridContainer.find('.input-searchbox').hide();
@@ -854,7 +867,7 @@ function getDefaultGridConfig() {
         function initGridFooter(serverSidePagination) {
             if(gridConfig.footer != false) {
                 gridContainer.append('<div class="grid-footer hide"></div>');
-                
+
                 gridContainer.find('.grid-footer').append('<div class="slick-pager"> \
                 		<span class="slick-pager-nav"> \
                 			<span class="pager-control"><i class="icon-step-backward icon-disabled pager-control-first"></i></span>\
@@ -866,7 +879,7 @@ function getDefaultGridConfig() {
                 		<span class="slick-pager-info"></span>\
                 		<span class="slick-pager-sizes"><div class="csg-pager-sizes"></div></span>\
                 	</div>');
-                
+
                 if(serverSidePagination) {
                     pager = new Slick.Controls.EnhancementPager({
                         gridContainer: gridContainer,
@@ -915,8 +928,7 @@ function getDefaultGridConfig() {
                  */
                 getCheckedRows: function(){
                     if (gridContainer.data('contrailGrid')._gridStates.allPagesDataChecked) {
-                        return dataView.getItems();
-                        //TODO Handle a case when data is filtered
+                        return dataView.getFilteredItems();
                     } else {
                         var selectedRows = grid.getSelectedRows(),
                             returnValue = [];
@@ -936,9 +948,10 @@ function getDefaultGridConfig() {
                  * Set All Checked Rows based on type == 'current-page' and 'all-page'
                  */
                 setAllCheckedRows: function(type) {
-                    var rows = [];
+                    var rows = [], dataLength = 0;
                     if (type == 'all-page') {
-                        for (var i = 0; i < dataView.getItems().length; i++) {
+                        dataLength = dataView.getFilteredItems().length;
+                        for (var i = 0; i < dataLength ; i++) {
                             var enabled = true;
                             if(contrail.checkIfFunction(gridOptions.checkboxSelectable.enableRowCheckbox)){
                                 enabled = gridOptions.checkboxSelectable.enableRowCheckbox(dataView.getItemById('id_' + i));
@@ -948,7 +961,8 @@ function getDefaultGridConfig() {
                             }
                         }
                     } else {
-                        for (var i = 0; i < grid.getDataLength(); i++) {
+                        dataLength = grid.getDataLength();
+                        for (var i = 0; i < dataLength ; i++) {
                             if(gridContainer.find('.rowCheckbox[value="' + i + '"]:disabled').length == 0) {
                                 rows.push(i);
                             }
@@ -991,19 +1005,46 @@ function getDefaultGridConfig() {
                 removeGridLoading: function(){
                     gridContainer.find('.grid-header-icon-loading').hide();
                 },
-                adjustAllRowHeight: function() {
-                	var self = this;
-                    gridContainer.find('.slick-row-master').each(function(){
-                    	self.adjustRowHeight($(this).data('cgrid'));
-                    });
-                },
-                adjustRowHeight: function(rowId) {
-                    var maxHeight = 20;
-                    gridContainer.find('.slick_row_' + rowId).find('.slick-cell').each(function(){
-                        maxHeight = ($(this).height() > maxHeight) ? $(this).height() : maxHeight;
-                    });
 
-                    gridContainer.find('.slick_row_' + rowId).height(maxHeight + 10);
+                adjustAllRowHeight: function() {
+                    if (!(gridOptions.fixedRowHeight != false && _.isNumber(gridOptions.fixedRowHeight))) {
+                        var self = this;
+                        clearTimeout(adjustAllRowHeightTimer);
+                        adjustAllRowHeightTimer = setTimeout(function () {
+                            var visibleRowIds = gridContainer.find('.slick-row-master').map(function () {
+                                    return $(this).data('cgrid');
+                                }),
+                                rowChunkSize = 25, visibleRowChunk = [];
+
+                            while (visibleRowIds.length > 0) {
+                                visibleRowChunk = visibleRowIds.splice(0, rowChunkSize);
+                                self.adjustRowHeightByChunk(visibleRowChunk);
+                            }
+                        }, 50);
+                    }
+                },
+
+                adjustRowHeightByChunk: function(rowChunks) {
+                    if (!(gridOptions.fixedRowHeight != false && _.isNumber(gridOptions.fixedRowHeight))) {
+                        var self = this;
+                        setTimeout(function () {
+                            $.each(rowChunks, function (chunkKey, chunkValue) {
+                                self.adjustRowHeight(chunkValue);
+                            });
+                        }, 5);
+                    }
+                },
+
+                adjustRowHeight: function(rowId) {
+                    if (!(gridOptions.fixedRowHeight != false && _.isNumber(gridOptions.fixedRowHeight))) {
+                        var maxHeight = 20;
+                        gridContainer.find('.slick_row_' + rowId).find('.slick-cell').each(function(){
+                            maxHeight = ($(this).height() > maxHeight) ? $(this).height() : maxHeight;
+                        });
+                        maxHeight = maxHeight + 10;
+
+                        gridContainer.find('.slick_row_' + rowId).height(maxHeight);
+                    }
                 },
                 adjustDetailRowHeight: function(rowId){
                 	var slickdetailRow = gridContainer.find('.slick_row_' + rowId).next('.slick-row-detail'),
@@ -1021,11 +1062,11 @@ function getDefaultGridConfig() {
                    	$.each(eventHandlerMap.dataView, function(key, val){
                        	dataView[key].unsubscribe(val);
                    	});
-                    
+
                    	$.each(eventHandlerMap.grid, function(key, val){
                        	grid[key].unsubscribe(val);
                     });
-                   	
+
                 	gridContainer.data('contrailGrid')._grid.destroy();
                     gridContainer.data('contrailGrid', null);
                     gridContainer.html('').removeClass('contrail-grid');
@@ -1074,7 +1115,7 @@ function getDefaultGridConfig() {
                     if (gridContainer.find('.rowCheckbox:disabled').length > 0) {
                         gridContainer.find('.headerRowCheckbox').attr('disabled', true)
                     }
-                }, 
+                },
                 /*
                  * Refreshes the detail view of the grid. Grid is rendered and related adjustments are made.
                  */
@@ -1099,7 +1140,7 @@ function getDefaultGridConfig() {
                  */
                 startAutoRefresh: function(refreshPeriod){
                 	startAutoRefresh(refreshPeriod);
-                }, 
+                },
                 /*
                  * Stops AutoRefresh
                  */
@@ -1218,7 +1259,7 @@ function getDefaultGridConfig() {
                 });
             });
         };
-        
+
         function addGridHeaderActionCheckedMultiselect(key, actionConfig, gridContainer) {
             var actions = actionConfig.actions,
                 actionId = (contrail.checkIfExist(actionConfig.actionId)) ? actionConfig.actionId : gridContainer.prop('id') + '-header-action-' + key;
@@ -1304,17 +1345,17 @@ var SlickGridPager = function (dataView, gridContainer, pagingInfo) {
     this.init = function() {
         var eventMap = gridContainer.data('contrailGrid')._eventHandlerMap.dataView;
         eventMap['onPagingInfoChanged'] = function (e, pagingInfo) {
-            var currentPageNum = null, currentPageSizeSelect = null;
+            var currentPageNum = null, currentPageSize = null;
 
             if (contrail.checkIfExist(currentPagingInfo)) {
                 currentPageNum = currentPagingInfo.pageNum;
-                currentPageSizeSelect = currentPagingInfo.pageSizeSelect;
+                currentPageSize = currentPagingInfo.pageSize;
             }
 
             pagingInfo.pageSizeSelect = pageSizeSelect;
             updatePager(pagingInfo);
 
-            if (pagingInfo.totalPages - pagingInfo.pageNum <= 1 || currentPagingInfo == null || currentPageNum != pagingInfo.pageNum || currentPageSizeSelect != pageSizeSelect) {
+            if (pagingInfo.totalPages - pagingInfo.pageNum <= 1 || currentPagingInfo == null || currentPageNum != pagingInfo.pageNum || currentPageSize != pagingInfo.pageSize) {
                 if(gridContainer.data('contrailGrid') != null && !gridContainer.data('contrailGrid')._gridStates.allPagesDataChecked) {
                     gridContainer.data('contrailGrid')._grid.setSelectedRows([])
                 }
@@ -1362,7 +1403,7 @@ var SlickGridPager = function (dataView, gridContainer, pagingInfo) {
     	footerContainer.find('.pager-control-prev').click(gotoPrev);
     	footerContainer.find('.pager-control-next').click(gotoNext);
     	footerContainer.find('.pager-control-last').click(gotoLast);
-    	
+
         csgCurrentPageDropDown = footerContainer.find('.csg-current-page').contrailDropdown({
             placeholder: 'Select..',
             data: [{id: 0, text: 'Page 1'}],


### PR DESCRIPTION
...rozen.

Issue:
Its a browser issue as it freezes due to mass DOM manipulations. The most expensive manipulation we do is adjusting row height for all the rows as we had a requirement where the rows were spanned across multiple lines and the same is not supported by slickgrid. Hence we end up doing it manually.
Fix:
- Added an option to set fixed row height to avoid further rendering
- Restricted page sizes dropdown options upto 200
- Added logic to manipulate the DOM in chunks. This will improve the user experience but browser will freeze when you try to scroll.
- Other code restructuring and optimizations

Change-Id: I730e0f7812f200d9849372eae4e8b9764a099f94