### PR TITLE
Closes-Bug: #1498242

### DIFF
--- a/src/serverroot/utils/common.utils.js
+++ b/src/serverroot/utils/common.utils.js
@@ -1377,21 +1377,26 @@ function getWebServerInfo (req, res, appData)
     serverObj['role'] = req.session.userRole;
     serverObj['featurePkg'] = {};
     serverObj['uiConfig'] = ui; 
-    serverObj['pkgList'] = [];
     var pkgList = process.mainModule.exports['pkgList'];
     var pkgLen = pkgList.length;
+    var activePkgs = [];
     for (var i = 1; i < pkgLen; i++) {
-        serverObj['pkgList'].push(pkgList[i]['pkgName']);
+        activePkgs.push(pkgList[i]['pkgName']);
     }
     /* It may happen that user has written same config multiple times in config
      * file
      */
-    serverObj['pkgList'] = _.uniq(serverObj['pkgList']);
+    activePkgs = _.uniq(activePkgs);
 
     serverObj['loggedInOrchestrationMode'] = req.session.loggedInOrchestrationMode;
 
-    for (var key in featurePackages) {
-        serverObj['featurePkg'][key] = featurePackages[key]['enable'];
+    var pkgCnt = activePkgs.length;
+    if (!pkgCnt) {
+        commonUtils.handleJSONResponse(null, res, serverObj);
+        return;
+    }
+    for (var i = 0; i < pkgCnt; i++) {
+        serverObj['featurePkg'][activePkgs[i]] = true;
     }
 
     commonUtils.handleJSONResponse(null, res, serverObj);

--- a/webroot/js/handlers/MenuHandler.js
+++ b/webroot/js/handlers/MenuHandler.js
@@ -19,15 +19,14 @@ define(['underscore'], function (_) {
         this.loadMenu = function () {
             var mFileName = 'menu.xml';
             var featureMaps = [];
-            if (null != webServerInfo['pkgList']) {
-                var pkgList = webServerInfo['pkgList'];
-                var pkgLen = pkgList.length;
-                for (var i = 0; i < pkgLen; i++) {
-                    if (null != featurePkgToMenuNameMap[pkgList[i]]) {
-                        featureMaps.push(featurePkgToMenuNameMap[pkgList[i]]);
+            if (null != webServerInfo['featurePkg']) {
+                var pkgList = webServerInfo['featurePkg'];
+                for (var key in pkgList) {
+                    if (null != featurePkgToMenuNameMap[key]) {
+                        featureMaps.push(featurePkgToMenuNameMap[key]);
                     } else {
                         console.log('featurePkgToMenuNameMap key is null: ' +
-                                    pkgList[i]);
+                                    key);
                     }
                 }
                 if (featureMaps.length > 0) {


### PR DESCRIPTION
While loading the menu/feature items and to see which features are enabled, we used to
use webServerInfo[featurePkg] which is not active one, but configured one in
config.global.js, so it may happen that some feature is specified as enabled in
config file, but directory does not exist, so we should take only active one.

Change-Id: I12222505fae42639ae5665477c71171fedd6207f