### PR TITLE
 Relate-Bug: #1476413

### DIFF
--- a/webroot/test/ui/js/co.test.constants.js
+++ b/webroot/test/ui/js/co.test.constants.js
@@ -4,20 +4,29 @@
 
 define([], function () {
     var COTestConstants = function () {
-
         this.TYPE_CONTRAIL_TEST = 'CONTRAIL_TEST';
         this.TYPE_CONTRAIL_TEST_SUITE = 'CONTRAIL_TEST_SUITE';
         this.TYPE_CONTRAIL_TEST_GROUP = 'CONTRAIL_TEST_GROUP';
 
-        this.VIEW_TEST = 'VIEW_TEST';
-        this.MODEL_TEST = 'MODEL_TEST';
-        this.UNIT_TEST = 'UNIT_TEST';
-        this.API_TEST = 'API_TEST';
-        this.LIB_API_TEST = 'LIB_API_TEST';
+        this.VIEW_TEST = 'VIEW_TEST'; //Tests ContrailView implementations
+        this.MODEL_TEST = 'MODEL_TEST'; //Tests ContrailModel implementations
+        this.UNIT_TEST = 'UNIT_TEST'; //Basic Unit tests
+        this.API_TEST = 'API_TEST'; //Tests the API section of UI
+        this.LIB_API_TEST = 'LIB_API_TEST'; //Tests third party library APIs
 
         this.SEVERITY_HIGH = 'high';
         this.SEVERITY_MEDIUM = 'medium';
         this.SEVERITY_LOW = 'low';
+        /**
+         * Minimum severity to run the tests.
+         * for severity set to low, all the tests set to severity above low will be executed.
+         * if this is set to empty, the severity set in the test config will be used.
+         */
+        this.RUN_SEVERITY = this.SEVERITY_LOW;
+
+        this.PAGE_LOAD_TIMEOUT = 1000;
+        this.PAGE_INIT_TIMEOUT = 50; // keep 50 or more.
+        this.ASSERT_TIMEOUT = 1000;
 
         this.MONITOR_NETWORKING_PAGE_LOADER = 'mnPageLoader';
         this.MONITOR_NETWORKING_ROOT_VIEW = this.MONITOR_NETWORKING_PAGE_LOADER + '.mnView';

--- a/webroot/test/ui/js/co.test.init.js
+++ b/webroot/test/ui/js/co.test.init.js
@@ -4,9 +4,9 @@
 
 var cowc, cowu, cowf, cowl, cowch, cowm, cotu, cotc, covdc;
 
-var allTestFiles = [], nmTestKarma = window.__karma__;
+var allTestFiles = [], windowKarma = window.__karma__;
 
-for (var file in nmTestKarma.files) {
+for (var file in windowKarma.files) {
     if (/\.test\.js$/.test(file)) {
         allTestFiles.push(file);
     }
@@ -152,7 +152,7 @@ function testAppInit(testAppConfig) {
                         }
 
                         function loadNextFileOrStartCoverage() {
-                            requirejs.undef(testFile);
+                            requirejs.undef(allTestFiles[testFilesIndex]);
                             console.log("Execution complete. Unloaded test file: " + allTestFiles[testFilesIndex].split('/').pop());
                             window.QUnit.config.current = {semaphore: 1};
                             window.QUnit.config.blocking = true;
@@ -175,6 +175,7 @@ function testAppInit(testAppConfig) {
                         };
 
                         defObj.done(loadNextFileOrStartCoverage);
+
                         loadSingleFileAndStartKarma(testFile, defObj, loadTestRunner);
 
                     });

--- a/webroot/test/ui/js/co.test.runner.js
+++ b/webroot/test/ui/js/co.test.runner.js
@@ -63,7 +63,7 @@ define([
         hashParams: {
             p: ''
         },
-        loadTimeout: 1000
+        loadTimeout: cotc.PAGE_LOAD_TIMEOUT
     };
 
     this.getDefaultPageConfig = function () {
@@ -204,8 +204,8 @@ define([
 
     this.executeCommonTests = function (testConfigObj) {
         _.each(testConfigObj, function (testConfig) {
-
             _.each(testConfig.suites, function (suiteConfig) {
+                suiteConfig.severity = cotc.RUN_SEVERITY;
                 if (contrail.checkIfExist(suiteConfig.class)) {
                     var testObj;
                     if (contrail.checkIfExist(testConfig.viewObj)) {
@@ -226,6 +226,7 @@ define([
     this.executeUnitTests = function (testConfigObj) {
         _.each(testConfigObj, function (testConfig) {
             _.each(testConfig.suites, function(suiteConfig) {
+                suiteConfig.severity = cotc.RUN_SEVERITY;
                 if (contrail.checkIfExist(suiteConfig.class)) {
                     suiteConfig.class(testConfig.moduleObj, suiteConfig);
                 }
@@ -244,7 +245,7 @@ define([
      * testConfig.getTestConfig()
      * @param PageTestConfig
      */
-    this.startCommonTestRunner = function (pageTestConfig) {
+    this.startTestRunner = function (pageTestConfig) {
         var self = this,
             fakeServer = null,
             fakeServerConfig = ifNull(pageTestConfig.fakeServer, self.getDefaultFakeServerConfig());
@@ -269,8 +270,7 @@ define([
             asyncTest("Load and Run Test Suite: ", function (assert) {
                 expect(0);
                 // commenting out for now. once UT lib update get the async working.
-                //var done = assert.async();
-                var done = null;
+                var done = assert.async();
 
                 switch (pageTestConfig.testType) {
                     case cotc.VIEW_TEST:
@@ -426,8 +426,7 @@ define([
         test: cTest,
         createTestGroup: createTestGroup,
         createTestSuite: createTestSuite,
-        startTestRunner: startCommonTestRunner,
-        startCommonTestRunner : startCommonTestRunner,
+        startTestRunner: startTestRunner,
         startViewTestRunner: startViewTestRunner,
         startModelTestRunner: startModelTestRunner,
         startLibTestRunner: startLibTestRunner,


### PR DESCRIPTION
1. tests will be run using the RUN_SEVERITY configured in the constants file.
2. page load timeout, page init timeout and assert timeout constants added.
test implementations needs to access these constants.
3. other minor changes.

Change-Id: I19ff8b5aae51b6cad47d389b15a8cf3d4b723041