### PR TITLE
Closes-Bug: #1524631

### DIFF
--- a/config/default.config.global.js
+++ b/config/default.config.global.js
@@ -311,7 +311,7 @@ config.multi_tenancy.enabled = true;
  * tampering
  *****************************************************************************/
 config.session = {};
-config.session.timeout = 24 * 60 * 60 * 1000;
+config.session.timeout = 1 * 60 * 60 * 1000;
 config.session.secret_key =
 'enterasupbK3xg8qescJK.dUbdgfVq0D70UaLTMGTzO4yx5vVJral2zIhVersecretkey';
 

--- a/src/serverroot/orchestration/plugins/plugins.api.js
+++ b/src/serverroot/orchestration/plugins/plugins.api.js
@@ -16,6 +16,7 @@ var authApi = require('../../common/auth.api');
 var logutils = require('../../utils/log.utils');
 var orch = require('../orchestration.api');
 var configUtils = require('../../common/configServer.utils');
+var global = require('../../common/global');
 var commonUtils = require('../../utils/common.utils');
 
 var orchModels = orch.getOrchestrationModels();
@@ -229,30 +230,25 @@ function setAllCookies (req, res, appData, cookieObj, callback)
         }
     }
     var defDomainId;
+    var cookieExp =
+        ((null != config.session) && (null != config.session.timeout)) ?
+        config.session.timeout : global.MAX_AGE_SESSION_ID;
+
+    var cookieExpStr = new Date(new Date().getTime() + cookieExp).toUTCString();
+    var secureCookieStr = (false == config.insecure_access) ? "; secure" : "";
     res.setHeader('Set-Cookie', 'username=' + cookieObj.username +
-                  '; expires=' +
-                  new Date(new Date().getTime() +
-                           global.MAX_AGE_SESSION_ID).toUTCString() +
-                  "; secure");
+                  '; expires=' + cookieExpStr + secureCookieStr);
     authApi.getCookieObjs(req, appData, function(cookieObjs) {
         if (null != cookieObjs['domain']) {
             res.setHeader('Set-Cookie', 'domain=' + cookieObjs['domain'] +
-                          '; expires=' +
-                          new Date(new Date().getTime() +
-                                   global.MAX_AGE_SESSION_ID).toUTCString() +
-                          "; secure");
+                          '; expires=' + cookieExpStr + secureCookieStr);
         }
         if (null != cookieObjs['project']) {
             res.setHeader('Set-Cookie', 'project=' + cookieObjs['project'] +
-                          '; expires=' +
-                          new Date(new Date().getTime() +
-                                   global.MAX_AGE_SESSION_ID).toUTCString() +
-                          "; secure");
+                          '; expires=' + cookieExpStr + secureCookieStr);
         }
         res.setHeader('Set-Cookie', '_csrf=' + req.session._csrf +
-                        '; expires=' + new Date(new Date().getTime() +
-                                                global.MAX_AGE_SESSION_ID).toUTCString()
-                        + '; secure');
+                      '; expires=' + cookieExpStr + secureCookieStr);
         callback();
     });
 }

--- a/src/serverroot/utils/common.utils.js
+++ b/src/serverroot/utils/common.utils.js
@@ -1389,6 +1389,7 @@ function getWebServerInfo (req, res, appData)
     activePkgs = _.uniq(activePkgs);
 
     serverObj['loggedInOrchestrationMode'] = req.session.loggedInOrchestrationMode;
+    serverObj['insecureAccess'] = config.insecure_access;
 
     var pkgCnt = activePkgs.length;
     if (!pkgCnt) {

--- a/src/tools/cutils.js
+++ b/src/tools/cutils.js
@@ -22,7 +22,7 @@ function getCookie(name) {
 
 function setCookie(name, value) {
     document.cookie = name + "=" + escape(value) +
-        "; expires=Sun, 17 Jan 2038 00:00:00 UTC; path=/; secure"
+        "; expires=Sun, 17 Jan 2038 00:00:00 UTC; path=/";
 }
 
 var class_A = 1;

--- a/webroot/js/contrail-common.js
+++ b/webroot/js/contrail-common.js
@@ -191,9 +191,17 @@ function Contrail() {
     };
 
     this.setCookie = function(name, value) {
-        var secureFlag = (globalObj['env'] != "test") ? "; secure" : "";
+        var secureCookieStr = "";
+        var insecureAccess =
+            getValueByJsonPath(globalObj, 'webServerInfo;insecureAccess',
+                               false);
+        if ("test" != globalObj['env']) {
+            secureCookieStr = "";
+        } else if (false == insecureAccess) {
+            secureCookieStr = "; secure";
+        }
         document.cookie = name + "=" + escape(value) +
-            "; expires=Sun, 17 Jan 2038 00:00:00 UTC; path=/" + secureFlag
+            "; expires=Sun, 17 Jan 2038 00:00:00 UTC; path=/" + secureCookieStr;
     };
 
     this.formatJSON2HTML = function(json, formatDepth){


### PR DESCRIPTION
1. Set secure flag to cookie only if insecure_access is set as false in config file
2. After /login registration with callback csrf(), do the usual /login callback
registration, as csrf() calls next() which in turn will call our handler,
earlier this call was not in order, our handler for /login was getting
registered first, so not calling csrf(), so _csrf token was coming as undefined.

Change-Id: I006e46f30088ed495f65ecb48b30608dd82f511e

Closes-Bug: #1525804
1. Default keystone token timeout is 1 hr, cookie timeout was hardcoded to 1 hr, in
stead of hard code take that from config session value.
2. Make session.timeout 1 hr.

Change-Id: I6e4fe97d6e9536f04f731e40dc286c4d72429645