### PR TITLE
Related-Bug: #1532666

### DIFF
--- a/src/serverroot/common/auth.api.js
+++ b/src/serverroot/common/auth.api.js
@@ -139,9 +139,22 @@ function getServiceCatalog (req, callback)
     });
 }
 
+function getUIUserRoleByTenant (userObj, callback)
+{
+    var req = userObj['req'];
+    return getAuthMethod[req.session.loggedInOrchestrationMode].getUIUserRoleByTenant(userObj,
+                                                                                      callback);
+}
+
 function getUIRolesByExtRoles (req, extRoles)
 {
-    return getAuthMethod[req.session.loggedInOrchestrationMode].getUserRoleByAuthResponse(extRoles);
+    return getAuthMethod[req.session.loggedInOrchestrationMode].getUIRolesByExtRoles(extRoles);
+}
+
+function getExtUserRoleByTenant (userObj, callback)
+{
+    var req = userObj['req'];
+    return getAuthMethod[req.session.loggedInOrchestrationMode].getExtUserRoleByTenant(userObj, callback);
 }
 
 function getCookieObjs (req, appData, callback)
@@ -177,6 +190,13 @@ function deleteAllTokens (req, callback)
     }
 }
 
+function getDomainNameByUUID (request, uuid, domList)
+{
+    return getAuthMethod[request.session.loggedInOrchestrationMode].getDomainNameByUUID(request,
+                                                                             uuid,
+                                                                             domList);
+}
+
 exports.doAuthenticate = doAuthenticate;
 exports.getTenantList = getTenantList;
 exports.getTokenObj = getTokenObj;
@@ -189,9 +209,13 @@ exports.getDomainList = getDomainList;
 exports.getProjectList = getProjectList;
 exports.isDefaultDomain = isDefaultDomain;
 exports.getNewTokenObjByToken = getNewTokenObjByToken;
-exports.getUIRolesByExtRoles = getUIRolesByExtRoles;
 exports.getDefaultDomain = getDefaultDomain;
 exports.getCookieObjs = getCookieObjs;
 exports.getSessionExpiryTime = getSessionExpiryTime;
 exports.getUserAuthDataByConfigAuthObj = getUserAuthDataByConfigAuthObj;
 exports.deleteAllTokens = deleteAllTokens;
+exports.getExtUserRoleByTenant = getExtUserRoleByTenant;
+exports.getDomainNameByUUID = getDomainNameByUUID;
+exports.getUIUserRoleByTenant = getUIUserRoleByTenant;
+exports.getUIRolesByExtRoles = getUIRolesByExtRoles;
+

--- a/src/serverroot/common/configServer.utils.js
+++ b/src/serverroot/common/configServer.utils.js
@@ -85,21 +85,14 @@ function getTenantListAndSyncDomain (request, appData, callback)
             if ((null != domId) && (false == authApi.isDefaultDomain(request, domId))) {
                 domId =
                     commonUtils.convertUUIDToString(tenantList['tenants'][i]['domain_id']);
-                if ((null != domain) && (domId != domain)) {
-                    tenantList['tenants'].splice(i, 1);
-                    i--;
-                    projCnt--;
-                    continue;
-                }
-            }
-            if ((null != domId) && (null == tmpDomainObjs[domId])) {
-                domainObjs['domains'].push({'fq_name': [domId], 'uuid': domId});
-                tmpDomainObjs[domId] = domId;
-                if (false == authApi.isDefaultDomain(request, domId)) {
-                    var domUrl = '/domain/' + domId;
-                    commonUtils.createReqObj(domArr, domUrl,
-                                             global.HTTP_REQUEST_GET, null,
-                                             null, null, appData);
+                if (null == tmpDomainObjs[domId]) {
+                    tmpDomainObjs[domId] = domId;
+                    if (false == authApi.isDefaultDomain(request, domId)) {
+                        var domUrl = '/domain/' + domId;
+                        commonUtils.createReqObj(domArr, domUrl,
+                                                 global.HTTP_REQUEST_GET, null,
+                                                 null, null, appData);
+                    }
                 }
             }
         }
@@ -109,8 +102,42 @@ function getTenantListAndSyncDomain (request, appData, callback)
                   function(err, confData) {
             getDomainsFromApiServer(appData, function(err, domList) {
                 if ((null != err) || (null == domList) || (null == domList['domains'])) {
+                    /* We did not find any domain in API Server */
+                    if ('v3' == request.session.authApiVersion) {
+                        /* In v2, we have default-domain for all projects */
+                        tenantList['tenants'] = [];
+                    }
                     callback(null, domainObjs, tenantList, domList);
                     return;
+                }
+                tmpDomainObjs = {};
+                for (var i = 0; i < projCnt; i++) {
+                    var domId = tenantList['tenants'][i]['domain_id'];
+                    if ((null != domId) &&
+                        (false == authApi.isDefaultDomain(request, domId))) {
+                        domId =
+                            commonUtils.convertUUIDToString(tenantList['tenants'][i]['domain_id']);
+                        var domFqn = authApi.getDomainNameByUUID(request, domId,
+                                                        domList['domains']);
+                        if ((null == tmpDomainObjs[domId]) && (null != domFqn)) {
+                            domainObjs['domains'].push({'fq_name': [domFqn], 'uuid': domId});
+                            tmpDomainObjs[domId] = domId;
+                        }
+                        if ((null != domain) && (domFqn != domain)) {
+                            tenantList['tenants'].splice(i, 1);
+                            i--;
+                            projCnt--;
+                        } else {
+                            tenantList['tenants'][i]['domain_name'] = domFqn;
+                        }
+                    } else {
+                        var defDomain = authApi.getDefaultDomain(request);
+                        if (null == tmpDomainObjs[domId]) {
+                            domainObjs['domains'].push({'fq_name': [defDomain], 'uuid': domId});
+                            tmpDomainObjs[domId] = domId;
+                        }
+                        tenantList['tenants'][i]['domain_name'] = defDomain;
+                    }
                 }
                 var allDomList = domList['domains'];
                 var allDomCnt = allDomList.length;

--- a/src/serverroot/orchestration/plugins/cloudstack/cloudstack.authApi.js
+++ b/src/serverroot/orchestration/plugins/cloudstack/cloudstack.authApi.js
@@ -51,10 +51,51 @@ function getUserRoleByAuthResponse (cloudStackUserLoginResp)
 {
     var userType = cloudStackUserLoginResp['loginresponse']['type'];
     if (CLOUDSTACK_USER_TYPE_ADMIN == userType) {
-        return global.STR_ROLE_ADMIN;
+        return [global.STR_ROLE_ADMIN];
     } else {
-        global.STR_ROLE_USER;
+        return [global.STR_ROLE_USER];
     }
+}
+
+function getUIUserRoleByTenant (userObj, callback)
+{
+    var userRoles = [global.STR_ROLE_USER];
+    if ((null == userObj) || (null == userObj.req)) {
+        callback(null, userRoles);
+        return;
+    }
+    userRoles =
+         commonUtils.getValueByJsonPath(userObj.req,
+                                        'session;userRole',
+                                        [global.STR_ROLE_USER]);
+    callback(null, userRoles);
+}
+
+function getUIRolesByExtRoles (extRoles)
+{
+    var roles = [];
+    if ((null == extRoles) || (!extRoles.length)) {
+        return [global.STR_ROLE_USER];
+    }
+    var roleCnt = extRoles.length;
+    for (var i = 0; i < roleCnt; i++) {
+        roles.push(extRoles[i]['name']);
+    }
+    if (-1 != roles.indexOf('admin')) {
+        return [global.STR_ROLE_ADMIN];
+    }
+    return [global.STR_ROLE_USER];
+}
+
+function getExtUserRoleByTenant (userObj, callback)
+{
+    getUIUserRoleByTenant(userObj, function(uiRoles) {
+        if (-1 != uiRoles.indexOf(global.STR_ROLE_ADMIN)) {
+            callback(null, {'roles': [{'name': 'admin'}]});
+            return;
+        }
+        callback(null, {'roles': [{'name': 'Member'}]});
+    });
 }
 
 function getUsers (req, callback)
@@ -209,4 +250,7 @@ exports.getProjectList = getProjectList;
 exports.getSessionExpiryTime = getSessionExpiryTime;
 exports.getUserAuthDataByConfigAuthObj = getUserAuthDataByConfigAuthObj;
 exports.deleteAllTokens = deleteAllTokens;
+exports.getUIUserRoleByTenant = getUIUserRoleByTenant;
+exports.getExtUserRoleByTenant = getExtUserRoleByTenant;
+exports.getUIRolesByExtRoles = getUIRolesByExtRoles;
 

--- a/src/serverroot/orchestration/plugins/no-orch/noOrchestration.api.js
+++ b/src/serverroot/orchestration/plugins/no-orch/noOrchestration.api.js
@@ -12,6 +12,7 @@ var config = process.mainModule.exports['config'];
 var commonUtils = require('../../../utils/common.utils');
 var messages = require('../../../common/messages');
 var configUtils = require('../../../common/configServer.utils');
+var roleMap = require('../../../web/core/rolemap.api');
 
 function authenticate (req, res, appData, callback)
 {
@@ -114,6 +115,47 @@ function getFlavors (req, callback)
     callback(null, list);
 }
 
+function getUIUserRoleByTenant (userObj, callback)
+{
+    var userRoles = [global.STR_ROLE_USER];
+    if ((null == userObj) || (null == userObj.req)) {
+        callback(null, userRoles);
+        return;
+    }
+    userRoles =
+        commonUtils.getValueByJsonPath(userObj.req,
+                                       'session;userRole',
+                                       [global.STR_ROLE_USER]);
+    callback(null, userRoles);
+}
+
+function getExtUserRoleByTenant (userObj, callback)
+{
+    getUIUserRoleByTenant(userObj, function(uiRoles) {
+        if (-1 != uiRoles.indexOf(global.STR_ROLE_ADMIN)) {
+            callback(null, {'roles': [{'name': 'admin'}]});
+            return;
+        }
+        callback(null, {'roles': [{'name': 'Member'}]});
+    });
+}
+
+function getUIRolesByExtRoles (extRoles)
+{
+    var roles = [];
+    if ((null == extRoles) || (!extRoles.length)) {
+        return [global.STR_ROLE_USER];
+    }
+    var roleCnt = extRoles.length;
+    for (var i = 0; i < roleCnt; i++) {
+        roles.push(extRoles[i]['name']);
+    }
+    if (-1 != roles.indexOf('admin')) {
+        return [global.STR_ROLE_ADMIN];
+    }
+    return [global.STR_ROLE_USER];
+}
+
 function getOSHostList (req, callback)
 {
     var list = {"hosts": []};
@@ -179,4 +221,7 @@ exports.getSessionExpiryTime = getSessionExpiryTime;
 exports.getToken = getToken;
 exports.getUserAuthDataByConfigAuthObj = getUserAuthDataByConfigAuthObj;
 exports.deleteAllTokens = deleteAllTokens;
+exports.getUIUserRoleByTenant = getUIUserRoleByTenant;
+exports.getExtUserRoleByTenant = getExtUserRoleByTenant;
+exports.getUIRolesByExtRoles = getUIRolesByExtRoles;
 

--- a/src/serverroot/orchestration/plugins/openstack/keystone.api.js
+++ b/src/serverroot/orchestration/plugins/openstack/keystone.api.js
@@ -41,11 +41,10 @@ if ((null != config) && (null != config.identityManager) &&
     }
 }
 
-/** Function: getUserRoleByAuthResponse
- *  1. This function is used to get the user role by keystone roleList response
- *  @private function
+/** Function: getUIRolesByExtRoles
+ *  1. This function is used to convert UI roles from external roles
  */
-function getUserRoleByAuthResponse (resRoleList)
+function getUIRolesByExtRoles (resRoleList)
 {
     var uiRoles = [];
     var tmpRoleObj = {};
@@ -53,7 +52,7 @@ function getUserRoleByAuthResponse (resRoleList)
         /* Ideally if Role is not associated, then we should not allow user to
          * login, but we are assigning role as 'Member' to the user to not to
          * block UI
-//        return null;
+        return null;
          */
         return [global.STR_ROLE_USER];
     }
@@ -237,9 +236,15 @@ function getAuthRetryData (token, req, reqUrl, callback)
     getAuthDataByReqUrl(req, token, reqUrl, function(err, data) {
         if ((err) &&
             (err.responseCode == global.HTTP_STATUS_AUTHORIZATION_FAILURE)) {
+            var tokenId = ((null != token) && (null != token.id)) ?
+                token.id : null;
+            var userObj = {'req': req, 'tenant': null, 'forceAuth': true};
+            if (null != tokenId) {
+                userObj['tokenid'] = tokenId;
+            }
+
             /* Get new Token and retry once again */
-            authApi.getTokenObj({'req': req, 'tenant': null,
-                                'forceAuth': true},
+            authApi.getTokenObj(userObj,
                                 function(error, token) {
                 if (error || (null == token)) {
                     commonUtils.redirectToLogout(req, req.res);
@@ -455,9 +460,13 @@ function getV3Token (authObj, callback)
                 callback(null,
                         authObj['req']['session']['tokenObjs'][authObj['tenant']]['token']);
             } catch(e) {
-                logutils.logger.error("We do not have the token Obj in " +
-                                      "session yet:" + e);
-                callback(null, token);
+                if (null == authObj['tokenid']) {
+                    var token = getLastIdTokenUsed(authObj['req']);
+                    if (null != token) {
+                        authObj['tokenid'] = token.id;
+                    }
+                }
+                getV3TokenByAuthObj(authObj, callback);
             }
             return;
         }
@@ -593,6 +602,7 @@ function sendV3CurlGetReq (dataObj, callback)
 
     var cmd = 'curl -s -H "X-Auth-Token: ' + token + '" ' +
         authProto + '://' + authIP + ':' + authPort + reqUrl;
+
     exec(cmd, function(err, stdout, stderr) {
         callback(err, JSON.parse(stdout));
     });
@@ -648,7 +658,7 @@ function formatV3AuthDataToV2AuthData (v3AuthData, authObj, callback)
         tokenObj['access']['token'] = v3TokenObj;
         tokenObj['access']['token']['id'] =
             removeSpecialChars(v3TokenObj['id']);
-        tokenObj['access']['serviceCatalog'] =  v3AuthData['token']['catalog'];
+        //tokenObj['access']['serviceCatalog'] =  v3AuthData['token']['catalog'];
         tokenObj['access']['user'] = {};
         tokenObj['access']['user']['username'] =
             v3AuthData['token']['user']['name'];
@@ -720,21 +730,18 @@ function doAuth (authObj, callback)
     This function is used to update the Token for a particular project in 
     req.session
  */
-function updateTokenIdForProject (req, tenantId, token)
+function updateTokenIdForProject (req, tenantId, accessData)
 {
-    if (null == tenantId) {
+    if ((null == tenantId) || (null == accessData)) {
         return;
     }
-    var projObj = getTokenIdByProject(req, tenantId);
-    if (projObj) {
-        try {
-            projObj['token'] = token.access.token;
-        } catch(e) {
-            logutils.logger.debug("In updateTokenIdForProject(), " +
-                                  "Got JSON parse error:" + e);
-            projObj['token'] = null;
-        }
+    delete accessData['serviceCatalog'];
+    if (null == req.session.tokenObjs[tenantId]) {
+        req.session.tokenObjs[tenantId] = {};
     }
+    req.session.tokenObjs[tenantId] = accessData;
+    req.session.userRoles = userRoleListByTokenObjs(req.session.tokenObjs);
+    return;
 }
 
 var getTokenCB = {
@@ -789,12 +796,9 @@ function getV2Token (authObj, callback)
     });
 }
 
-function updateLastTokenUsed (req, data)
+function updateLastTokenUsed (req, token)
 {
-    if ((null != data) && (null != data.access) && 
-        (null != data.access.token)) {
-        req.session.last_token_used = data.access.token;
-    }
+    req.session.last_token_used = token;
 }
 
 function getTokenIdByProject (req, tenantName)
@@ -811,11 +815,8 @@ function getUserAuthData (req, tenantName, callback)
 {
     var token = getTokenIdByProject(req, tenantName);
     if (null == token) {
-        /* We did not get the token available, so redirect to login page */
-        commonUtils.redirectToLogout(req, req.res);
-        return;
+        var token = getLastIdTokenUsed(req);
     }
-    var lastTokenUsed = getLastIdTokenUsed(req);
     var authObj = {};
     authObj['tokenid'] = token.id;
     if (null == tenantName) {
@@ -823,14 +824,17 @@ function getUserAuthData (req, tenantName, callback)
     }
     authObj['tenant'] = tenantName;
     getUserAuthDataByAuthObj (authObj, function(err, data) {
-        if ((null != err) || (null == data)) {
+        if ((null != err) || (null == data) || (null == data.access) ||
+            (null == data.access.token)) {
             callback(err, data);
             return;
         }
-        updateTokenIdForProject(req, tenantName, data);
-        authApi.checkAndUpdateDefTenantToken(req, tenantName, data);
-        updateLastTokenUsed(req, data);
-        callback(null, data);
+        var token = data.access.token;
+        var dataAccess = commonUtils.cloneObj(data);
+        updateTokenIdForProject(req, tenantName, data.access);
+        updateDefTenantToken(req, tenantName, data);
+        updateLastTokenUsed(req, token);
+        callback(null, dataAccess);
     });
 }
 
@@ -920,7 +924,21 @@ function getServiceCatalog (req, callback)
     });
 }
 
-function getUserRoleByTenant (userObj, callback)
+function getUIUserRoleByTenant (userObj, callback)
+{
+    var roles = [];
+    getExtUserRoleByTenant(userObj, function(err, data) {
+        if ((null != err) || (null == data) ||
+            (null == data['roles'])) {
+            callback(null, [global.STR_ROLE_USER]);
+            return;
+        }
+        roles = getUIRolesByExtRoles(data['roles']);
+        callback(null, roles);
+    });
+}
+
+function getExtUserRoleByTenant (userObj, callback)
 {
     var userTokenObj = {};
     var username = userObj['username'];
@@ -932,6 +950,10 @@ function getUserRoleByTenant (userObj, callback)
             (null != data['access']['user']['roles'])) {
             userTokenObj['roles'] = data['access']['user']['roles'];
             userTokenObj['tokenObj'] = data['access'];
+            if ((null != userObj['req']) && (null != tenant)) {
+                 updateTokenIdForProject(userObj['req'], tenant,
+                                         data.access);
+            }
             callback(null, userTokenObj);
         } else {
             callback(null, null);
@@ -950,6 +972,7 @@ function getUserRoleByAllTenants (username, password, tenantlist, callback)
     var tenantCnt = tenantlist.length;
     var userRoles = [global.STR_ROLE_USER];
 
+    /* Do only for the last tenant */
     for (var i = 0; i < tenantCnt; i++) {
         if ((null != tenantlist[i]) && (null != tenantlist[i]['name'])) {
             tenantObjArr[i] = {'username': username, 'password': password,
@@ -960,7 +983,7 @@ function getUserRoleByAllTenants (username, password, tenantlist, callback)
         return userRoles;
     }
 
-    async.map(tenantObjArr, getUserRoleByTenant, function(err, data) {
+    async.map(tenantObjArr, getExtUserRoleByTenant, function(err, data) {
         if (data) {
             var roleList = [];
             var dataLen = data.length;
@@ -974,8 +997,10 @@ function getUserRoleByAllTenants (username, password, tenantlist, callback)
                     continue;
                 }
                 tokenObjs[project] = data[i]['tokenObj'];
+                /* We do not need service catalog */
+                delete tokenObjs[project]['serviceCatalog'];
                 userRoles =
-                    getUserRoleByAuthResponse(data[i]['roles']);
+                    getUIRolesByExtRoles(data[i]['roles']);
                 var userRolesCnt = userRoles.length;
                 for (var j = 0; j < userRolesCnt; j++) {
                     if (null == tmpUIRoleObjs[userRoles[j]]) {
@@ -992,7 +1017,7 @@ function getUserRoleByAllTenants (username, password, tenantlist, callback)
 var makeAuthCB = {
     'v2.0': doV2Auth,
     'v3': doV3Auth
-}
+};
 
 function makeAuth (req, startIndex, lastErrStr, callback)
 {
@@ -1060,19 +1085,6 @@ function authenticate (req, res, appData, callback)
                 logutils.logger.error("Very much unexpected, we came here!!!");
                 errStr = "Unexpected event happened";
             }
-            commonUtils.changeFileContentAndSend(res, loginErrFile,
-                                                 global.CONTRAIL_LOGIN_ERROR,
-                                                 errStr, function() {
-            });
-            return;
-        }
-        var multiTenancyEnabled = commonUtils.isMultiTenancyEnabled();
-        if ((true == multiTenancyEnabled) &&
-            (false == isAdminRoleInProjects(req.session.userRoles))) {
-            /* Logged in user is not admin in multi_tenancy mode,
-               so redirect to login page
-             */
-            errStr = "Only admin user is allowed to login"
             commonUtils.changeFileContentAndSend(res, loginErrFile,
                                                  global.CONTRAIL_LOGIN_ERROR,
                                                  errStr, function() {
@@ -1164,12 +1176,13 @@ function getUserRoleByProjectList (projects, userObj, callback)
 {
     var resTokenObjs = {};
     var userRole = global.STR_ROLE_USER;
-    getProjectDetails (projects, userObj, function(err, projs, tokenObjs) {
+    getProjectDetails(projects, userObj, function(err, projs, tokenObjs) {
         if ((null != err) || (null == projs)) {
             callback(null, tokenObjs);
             return;
         }
         var projCnt = projs.length;
+        /* Only the last project- default project */
         for (var i = 0; i < projCnt; i++) {
             try {
                 var projName =
@@ -1188,6 +1201,10 @@ function getUserRoleByProjectList (projects, userObj, callback)
                     resTokenObjs[projName]['user'] = {};
                     resTokenObjs[projName]['user']['roles'] =
                         resTokenObjs[projName]['token']['roles'];
+                    try {
+                        delete resTokenObjs[projName]['token']['catalog'];
+                    } catch(e) {
+                    }
                 }
             } catch(e) {
                 logutils.logger.error("In getUserRoleByProjectList(): JSON " + 
@@ -1199,7 +1216,7 @@ function getUserRoleByProjectList (projects, userObj, callback)
             var roles =
                 commonUtils.getValueByJsonPath(projs[i],
                                                'token;roles', null);
-            var userRole = getUserRoleByAuthResponse(roles);
+            var userRole = getUIRolesByExtRoles(roles);
             if (global.STR_ROLE_ADMIN == userRole) {
                 callback(userRole, resTokenObjs);
                 return;
@@ -1268,6 +1285,25 @@ function doV3Auth (req, callback)
                     callback(messages.error.unauthorized_to_project);
                     return;
                 }
+                var projectCookie =
+                    commonUtils.getValueByJsonPath(req,
+                                                   'cookies;project',
+                                                   null);
+                var lastTenantObj = projects['projects'][projects['projects'].length - 1];
+                var cookieProjObj = null;
+                if (null != projectCookie) {
+                    var tenantsCnt = projects['projects'].length;
+                    for (var i = 0; i < tenantsCnt; i++) {
+                        if ((projectCookie == projects['projects'][i]['name']) &&
+                            (projectCookie != lastTenantObj['name'])) {
+                            cookieProjObj = projects['projects'][i];
+                        }
+                    }
+                }
+                projects['projects'] = [lastTenantObj];
+                if (null != cookieProjObj) {
+                    projects['projects'].push(cookieProjObj);
+                }
                 getUserRoleByProjectList(projects['projects'], userObj,
                                          function(roleStr, tokenObjs) {
                     req.session.def_token_used = tokenObjs[defProject]['token'];
@@ -1276,7 +1312,7 @@ function doV3Auth (req, callback)
                     req.session.userRoles =
                         userRoleListByTokenObjs(tokenObjs);
                     updateTokenIdForProject(req, defProject,
-                                            req.session.def_token_used);
+                                            tokenObjs[defProject]);
                     req.session.isAuthenticated = true;
                     req.session.userRole = roleStr;
                     req.session.domain = domain;
@@ -1335,10 +1371,30 @@ function doV2Auth (req, callback)
         /* Now check the tenants attached to this user */
         req.session.last_token_used = data.access.token;
         getTenantListByToken(req, data.access.token, function(err, data) {
-            if ((null == data) || (null == data.tenants)) {
+            if ((null == data) || (null == data.tenants) ||
+                (!data.tenants.length)) {
                 req.session.isAuthenticated = false;
                 callback(messages.error.unauthorized_to_project);
                 return;
+            }
+            var projectCookie =
+                commonUtils.getValueByJsonPath(req,
+                                               'cookies;project',
+                                               null);
+            var lastTenantObj = data.tenants[data.tenants.length - 1];
+            var cookieProjObj = null;
+            if (null != projectCookie) {
+                var tenantsCnt = data.tenants.length;
+                for (var i = 0; i < tenantsCnt; i++) {
+                    if ((projectCookie == data.tenants[i]['name']) &&
+                        (projectCookie != lastTenantObj['name'])) {
+                        cookieProjObj = data.tenants[i];
+                    }
+                }
+            }
+            data.tenants = [lastTenantObj];
+            if (null != cookieProjObj) {
+                data.tenants.push(cookieProjObj);
             }
             var projCount = data.tenants.length;
             if (!projCount) {
@@ -1382,8 +1438,9 @@ function doV2Auth (req, callback)
                         req.session.userRoles =
                             userRoleListByTokenObjs(tokenObjs);
                         //setSessionTimeoutByReq(req);
-                        updateTokenIdForProject(req, defProject, data);
-                        updateLastTokenUsed(req, data);
+                        updateTokenIdForProject(req, defProject,
+                                                data.access);
+                        updateLastTokenUsed(req, data.access.token);
                         logutils.logger.info("Login Successful with tenants.");
                         callback(null);
                     });
@@ -1400,6 +1457,9 @@ function getV3DomainIfNotAvailable (domain)
         if (null == domain) {
             domain = global.KEYSTONE_V3_DEFAULT_DOMAIN;
         }
+    }
+    if (global.KEYSTONE_V2_DEFAULT_DOMAIN == domain) {
+        return global.KEYSTONE_V3_DEFAULT_DOMAIN;
     }
     return domain;
 }
@@ -1607,6 +1667,7 @@ function getDomainByTokenObjKey (tokenObjKey, req)
 
 function filterProjectList (req, projectList)
 {
+    return projectList;
     var filtProjects = {'projects': []};
     var adminProjs = buildAdminProjectListByReqObj(req);
     var projects = projectList['projects'];
@@ -1653,6 +1714,8 @@ function getProjectList (req, appData, callback)
                 return;
             }
             var filtProjects = filterProjectList(req, keystoneProjs);
+            callback(null, filtProjects);
+            return;
             var projects = keystoneProjs['projects'];
             var projCnt = projects.length;
             var tokenObjs = req.session.tokenObjs;
@@ -1667,22 +1730,33 @@ function getProjectList (req, appData, callback)
                         break;
                     }
                 }
-                if (false == found) {
+                if ((false == found) && (filtProjects['projects'].length > 0)) {
                     /* We did not find the project in our tokenObj, so get the
                      * token/role for this and update the tokenObjs
                      */
-                    tenantObjArr.push({'tenant': projects[i]['fq_name'][1],
+
+                    if (null != filtProjects['projects'][0]['fq_name']) {
+                        var tokenObj =
+                            req.session.tokenObjs[filtProjects['projects'][0]['fq_name'][1]];
+                        if (null != tokenObj) {
+                            var tokenId =
+                                commonUtils.getValueByJsonPath(tokenObj,
+                                                               'token;id',
+                                                               null);
+                            if (null != tokenId) {
+                                tenantObjArr.push({'tenant': projects[i]['fq_name'][1],
                                       'domain': projects[i]['fq_name'][0],
-                                      'req': req,
-                                      'tokenid':
-                                      req.session.tokenObjs[filtProjects['projects'][0]['fq_name'][1]].token.id});
+                                      'req': req, 'tokenid': tokenId});
+                            }
+                        }
+                    }
                 }
             }
             if (!tenantObjArr.length) {
                 callback(error, filtProjects);
                 return;
             }
-            async.map(tenantObjArr, getUserRoleByTenant, function(err, data) {
+            async.map(tenantObjArr, getExtUserRoleByTenant, function(err, data) {
                 var dataLen = data.length;
                 for (var i = 0; i < dataLen; i++) {
                     var project =
@@ -1700,7 +1774,7 @@ function getProjectList (req, appData, callback)
                         continue;
                     }
                     req.session.tokenObjs[project] = data[i]['tokenObj'];
-                    var userRoles = getUserRoleByAuthResponse(data[i]['roles']);
+                    var userRoles = getUIRolesByExtRoles(data[i]['roles']);
                     var rolesCnt = data[i]['roles'].length;
                     var tmpRoleList = [];
                     for (var j = 0; j < rolesCnt; j++) {
@@ -1855,12 +1929,12 @@ function getAdminProjectList (req, appData, callback)
                     if (null == roles[i]['name']) {
                         continue;
                     }
-                    if (adminRoles[j].toUpperCase() == roles[i]['name'].toUpperCase()) {
+                    //if (adminRoles[j].toUpperCase() == roles[i]['name'].toUpperCase()) {
                         if (null == adminProjectObjs[domain]) {
                             adminProjectObjs[domain] = [];
                         }
                         adminProjectObjs[domain].push(key);
-                    }
+                    //}
                 }
             }
         }
@@ -2124,8 +2198,12 @@ exports.getProjectList = getProjectList;
 exports.isDefaultDomain = isDefaultDomain;
 exports.getDefaultDomain = getDefaultDomain;
 exports.getUserAuthDataByAuthObj = getUserAuthDataByAuthObj;
-exports.getUserRoleByAuthResponse = getUserRoleByAuthResponse;
 exports.getCookieObjs = getCookieObjs;
 exports.getSessionExpiryTime = getSessionExpiryTime;
 exports.getUserAuthDataByConfigAuthObj = getUserAuthDataByConfigAuthObj;
 exports.deleteAllTokens = deleteAllTokens;
+exports.getExtUserRoleByTenant = getExtUserRoleByTenant;
+exports.getDomainNameByUUID = getDomainNameByUUID;
+exports.getUIUserRoleByTenant = getUIUserRoleByTenant;
+exports.getUIRolesByExtRoles = getUIRolesByExtRoles;
+

--- a/src/serverroot/orchestration/plugins/plugins.api.js
+++ b/src/serverroot/orchestration/plugins/plugins.api.js
@@ -208,19 +208,6 @@ function setAllCookies (req, res, appData, cookieObj, callback)
             appData['authObj']['defTokenObj'] =
                 req.session.tokenObjs[adminProjectList[0]]['token'];
         } else {
-            /* Check if multi_tenancy enabled */
-            if (true == multiTenancyEnabled) {
-                /* We should not come here, multi_tenancy enabled, why we came
-                 * here still
-                 */
-                logutils.logger.error("No Admin Projects!!!");
-                errStr = "No admin projects";
-                commonUtils.changeFileContentAndSend(res, loginErrFile,
-                                                     global.CONTRAIL_LOGIN_ERROR,
-                                                     errStr, function() {
-                });
-                return;
-            }
             var tokenObjs = req.session.tokenObjs;
             for (key in tokenObjs) {
                 appData['authObj']['defTokenObj'] =

--- a/src/serverroot/orchestration/plugins/vcenter/vcenter.authApi.js
+++ b/src/serverroot/orchestration/plugins/vcenter/vcenter.authApi.js
@@ -135,6 +135,22 @@ function getProjectList (req, appData, callback)
     });
 }
 
+function getUIUserRoleByTenant (userObj, callback)
+{
+    var roles = [global.STR_ROLE_ADMIN];
+    callback(null, roles);
+}
+
+function getExtUserRoleByTenant (userObj, callback)
+{
+    callback(null, {'roles': [{'name': 'admin'}]});
+}
+
+function getUIRolesByExtRoles (extRoles)
+{
+    return [global.STR_ROLE_ADMIN];
+}
+
 function getImageList (req, callback)
 {
     var imgList = {"images": []};
@@ -222,4 +238,7 @@ exports.getServiceInstanceVMStatus = getServiceInstanceVMStatus;
 exports.getVMStatsByProject = getVMStatsByProject;
 exports.getUserAuthDataByConfigAuthObj = getUserAuthDataByConfigAuthObj;
 exports.deleteAllTokens = deleteAllTokens;
+exports.getUIUserRoleByTenant = getUIUserRoleByTenant;
+exports.getExtUserRoleByTenant = getExtUserRoleByTenant;
+exports.getUIRolesByExtRoles = getUIRolesByExtRoles;
 

--- a/src/serverroot/web/routes/handler.js
+++ b/src/serverroot/web/routes/handler.js
@@ -206,24 +206,6 @@ setSessionTimeoutByReq = function(req) {
     }
 }
 
-getUserRoleByAuthResponse = function(resRoleList) {
-    if ((null == resRoleList) || (!resRoleList.length)) {
-        /* Ideally if Role is not associated, then we should not allow user to
-         * login, but we are assigning role as 'Member' to the user to not to
-         * block UI
-//        return null;
-         */
-        return global.STR_ROLE_USER;
-    }
-    var rolesCount = resRoleList.length;
-    for (var i = 0; i < rolesCount; i++) {
-        if (resRoleList[i]['name'] != 'Member') {
-            return global.STR_ROLE_ADMIN;
-        }
-    }
-    return global.STR_ROLE_USER;
-}
-
 exports.authenticate = function (req, res, appData) {
     /* Call module independent API */
     authApi.doAuthenticate(req, res, appData, function(err, data) {

--- a/webroot/js/contrail-common.js
+++ b/webroot/js/contrail-common.js
@@ -206,6 +206,7 @@ function Contrail() {
     };
 
     this.setCookie = function(name, value) {
+        var oldCookie = contrail.getCookie(name);
         var secureCookieStr = "";
         var insecureAccess =
             getValueByJsonPath(globalObj, 'webServerInfo;insecureAccess',
@@ -217,6 +218,9 @@ function Contrail() {
         }
         document.cookie = name + "=" + escape(value) +
             "; expires=Sun, 17 Jan 2038 00:00:00 UTC; path=/" + secureCookieStr;
+        if (('project' == name) && (oldCookie != value)) {
+            layoutHandler.load();
+        }
     };
 
     this.formatJSON2HTML = function(json, formatDepth, ignoreKeys){

--- a/webroot/js/handlers/ContentHandler.js
+++ b/webroot/js/handlers/ContentHandler.js
@@ -86,13 +86,13 @@ define(['underscore'], function (_) {
                         if(webServerInfo['orchestrationModel'].length == 1)
                             currPageHash = "mon_infra_dashboard";
                         else
-                            currPageHash = 'mon_net_dashboard';
+                            currPageHash = 'mon_networking_dashboard';
                     } else if(webServerInfo['featurePkg']['serverManager'] && !webServerInfo['featurePkg']['webController']) {
                         currPageHash = "setting_sm_clusters";
                     } else if($.inArray(roles['ADMIN'], webServerInfo['role']) > -1) {
                         currPageHash = "mon_infra_dashboard";
                     } else if ($.inArray(roles['TENANT'], webServerInfo['role']) > -1) {
-                        currPageHash = "mon_net_dashboard";
+                        currPageHash = "mon_networking_dashboard";
                     }
                 }
                 var currMenuObj = menuHandler.getMenuObjByHash(currPageHash);

--- a/webroot/js/handlers/LayoutHandler.js
+++ b/webroot/js/handlers/LayoutHandler.js
@@ -12,7 +12,8 @@ define(['underscore', 'menu-handler', 'content-handler'], function (_, MenuHandl
         this.load = function () {
             menuHandler = new MenuHandler();
 
-            getWebServerInfo(function(webServerInfo) {
+            getWebServerInfo(contrail.getCookie('project'),
+                             function(webServerInfo) {
                 menuHandler.loadMenu(webServerInfo);
                 menuHandler.handleSideMenu();
                 /**
@@ -106,10 +107,10 @@ define(['underscore', 'menu-handler', 'content-handler'], function (_, MenuHandl
     return LayoutHandler;
 });
 
-function getWebServerInfo(callback) {
+function getWebServerInfo(project, callback) {
     //Compares client UTC time with the server UTC time and display alert if mismatch exceeds the threshold
     $.ajax({
-        url: '/api/service/networking/web-server-info'
+        url: '/api/service/networking/web-server-info?project=' + project
     }).done(function (webServerInfo) {
         if (webServerInfo['serverUTCTime'] != null) {
             webServerInfo['timeDiffInMillisecs'] = webServerInfo['serverUTCTime'] - new Date().getTime();


### PR DESCRIPTION
1. Allow member role users also to login.
2. Earlier we used to allow only admin role users, due to which we had to get
all the roles per project while log-in, if there are a lot of projects for this
user, then it used to take lot of time to get this info, so login time was more.
3. Once log-in if the user has member role for this project set in cookie, then
some menu itesm will be disabled, only switching to admin project from config
page, the menu will get enabled, it is same as horizon behavior.
4. Corrected the hash value of mon_net_dashboard -> mon_networking_dashboard

Change-Id: I07263eeef23e028740f2b9edfa6e34ac28e49362