### PR TITLE
Closes-Bug: #1559943

### DIFF
--- a/src/serverroot/orchestration/plugins/openstack/keystone.api.js
+++ b/src/serverroot/orchestration/plugins/openstack/keystone.api.js
@@ -48,12 +48,15 @@ function getUIRolesByExtRoles (resRoleList)
 {
     var uiRoles = [];
     var tmpRoleObj = {};
+    var extRoleList = [];
     if ((null == resRoleList) || (!resRoleList.length)) {
         /* Ideally if Role is not associated, then we should not allow user to
          * login, but we are assigning role as 'Member' to the user to not to
          * block UI
         return null;
          */
+        logutils.logger.error('User does not have role associated, so UI ' +
+                              'assigning to member role');
         return [global.STR_ROLE_USER];
     }
     var rolesCount = resRoleList.length;
@@ -68,6 +71,7 @@ function getUIRolesByExtRoles (resRoleList)
         if (null == extRoleStr) {
             continue;
         }
+        extRoleList.push(extRoleStr);
         extRoleStr = extRoleStr.toUpperCase();
         if ((null != tmpUIRoleMapList[extRoleStr]) &&
             (null == tmpRoleObj[tmpUIRoleMapList[extRoleStr]])) {
@@ -79,6 +83,9 @@ function getUIRolesByExtRoles (resRoleList)
     if (uiRoles.length) {
         return uiRoles;
     }
+    logutils.logger.error('Keystone roles <' + extRoleList.join(',') +
+                          '> not mapped with UI Role, so UI ' +
+                          'assigning to member role');
     return [global.STR_ROLE_USER];
 }
 


### PR DESCRIPTION
We are using roleList.xml (in web-core) to define external roles (like keystone
roles) to UI roles, this xml file used to create rolemap.api.js at compile time,
now as user may want to add a new role at run time, so now on wards, web-ui at
start time will scan for a file in /etc/contrail/contrail-webui-rolelist.xml
file, if found then role mapping will be done based on this file, else from
roleList.xml file as coming default with the repo.

Change-Id: I83e0d9f616adc4878f15c5b2b418fb1474a0230c