### PR TITLE
Closes-Bug: #1553413 fix onAllRequestCompleteCB

### DIFF
--- a/webroot/js/views/ContrailView.js
+++ b/webroot/js/views/ContrailView.js
@@ -85,7 +85,18 @@ define([
                     modelMap: modelMap,
                     app: app,
                     rootView: rootView,
-                    onAllViewsRenderCompleteCB: function() {return;}
+                    onAllViewsRenderCompleteCB: function() {
+                        if(!self.isAnyViewRenderInProgress()) {
+                            // Notify parent the one of child's rendering is complete.
+                            self.onAllViewsRenderComplete.notify();
+
+                            if(contrail.checkIfFunction(onAllViewsRenderComplete)) {
+                                // Call any callback associated with onViewRenderComplete of child view.
+                                onAllViewsRenderComplete(self);
+                            }
+                        }
+
+                    }
                     /*
                     onAllRenderCompleteCB: function() {
                         if(!self.isAnyViewRenderInProgress()) {


### PR DESCRIPTION
- onAllRequestCompleteCB is used outside of the test infra as well.
retained original logic for the callback and new completion logic is used in UT
- for UT, notification logic is to wait for both child views and no outstanding
ajax requests active.
- wait on ajax can lead to break some views if the requests are taking too long
to finish. (Request timeouts)
- TODO: add additional functionality inside the viewsRenderCompleteEventNotifier
to wait for views or data or for both. And enable it universally.

Change-Id: I239e352ae477919b618726b622866392988ff4f1