### PR TITLE
Related-Bug: #1580038

### DIFF
--- a/webroot/build/config.generator.constants.js
+++ b/webroot/build/config.generator.constants.js
@@ -311,7 +311,8 @@ constants.coreModules  = [
         ],
         exclude: [
             'jquery','jquery-ui','knockout','bootstrap','jquery.xml2json',
-            'jquery.ba-bbq','jquery.json','d3','backbone','validation'
+            'jquery.ba-bbq','jquery.json','d3','backbone','validation',
+            'core-bundle'
         ],
         override: {
             wrapShim: false

--- a/webroot/build/config.generator.js
+++ b/webroot/build/config.generator.js
@@ -158,7 +158,13 @@ ControllerConfigGenerator.prototype = new CoreConfigGenerator();
 ControllerConfigGenerator.prototype.overrideBaseConfig = function() {
     // Update core app paths with relative paths.
     for (var path in this.configJSON.paths) {
-        this.configJSON.paths[path] = confGenConst.controllerCoreRelativePath + this.configJSON.paths[path];
+        //text plugin need to be loaded by the loader to process text! dependencies
+        if(path == "text") {
+            this.configJSON.paths[path] = confGenConst.controllerCoreRelativePath + this.configJSON.paths[path];
+        } else {
+            //To avoid core repo files from being bundled into controller bundles
+            this.configJSON.paths[path] = "empty:";
+        }
     }
     // Add controller paths.
     var controllerApp = require('./../../../contrail-web-controller/webroot/common/ui/js/controller.app')

--- a/webroot/js/models/NodeConsoleLogsModel.js
+++ b/webroot/js/models/NodeConsoleLogsModel.js
@@ -5,8 +5,9 @@
 define([
     'underscore',
     'knockout',
-    'query-form-model'
-], function (_, Knockout, QueryFormModel) {
+    'query-form-model',
+    'core-basedir/js/common/qe.model.config'
+], function (_, Knockout, QueryFormModel,qewmc) {
     var NodeConsoleLogsModel = QueryFormModel.extend({
 
         defaultSelectFields: [],

--- a/webroot/js/views/AlarmGridView.js
+++ b/webroot/js/views/AlarmGridView.js
@@ -8,8 +8,9 @@ define([
     'contrail-list-model',
     'js/views/AlarmsEditView',
     'js/models/AlarmsModel',
-    'core-alarm-parsers'
-], function (_, ContrailView, ContrailListModel, AlarmsEditView, AlarmsModel,coreAlarmParsers) {
+    'core-alarm-parsers',
+    'core-alarm-utils'
+], function (_, ContrailView, ContrailListModel, AlarmsEditView, AlarmsModel,coreAlarmParsers,coreAlarmUtils) {
     var alarmsEditView = new AlarmsEditView();
     var GridDS, parentModel;
     var AlarmGridView = ContrailView.extend({

--- a/webroot/js/views/AlarmListView.js
+++ b/webroot/js/views/AlarmListView.js
@@ -8,7 +8,7 @@ define([
     'contrail-list-model',
     'cf-datasource',
     'core-alarm-parsers',
-    'core-alarm-utils',
+    'core-alarm-utils'
 ], function (_, ContrailView, ContrailListModel, CFDataSource,coreAlarmParsers,coreAlarmUtils) {
     var AlarmListView = ContrailView.extend({
         el: $(contentContainer),


### PR DESCRIPTION
1. Added core-bundle to exclude list while building nonamd.libs bundle,such
that the core-bundle files don't get added to nonamd.libs even if they
turn up as dependencies
2. Set the path for core-repo files to "empty:" to ensure that core-repo
   files don't get bundled into controller bundles
3. Added qe/alarm helpers as dependencies whereever required

Change-Id: I90e828a9ff086cab9e751aaa553257528c8a1545