### PR TITLE
Closes-Bug: #1599319

### DIFF
--- a/webroot/js/views/BreadcrumbDropdownView.js
+++ b/webroot/js/views/BreadcrumbDropdownView.js
@@ -43,7 +43,8 @@ define([
                 dropdownOptions = viewConfig.dropdownOptions,
                 parentSelectedValueData = contrail.checkIfExist(dropdownOptions.parentSelectedValueData) ? dropdownOptions.parentSelectedValueData : null,
                 dropdownData = (self.model === null) ? [] : self.model.getItems(),
-                dropdownElementId = self.attributes.elementId;
+                dropdownElementId = self.attributes.elementId,
+                defaultValueIndex = ((contrail.checkIfExist(dropdownOptions.defaultValueIndex) && dropdownData.length > 0) ? dropdownOptions.defaultValueIndex : 0);
 
             if (contrail.checkIfExist(dropdownOptions.allDropdownOption)) {
                 dropdownData = dropdownOptions.allDropdownOption.concat(dropdownData);
@@ -99,7 +100,7 @@ define([
 
                     selectedValueData = (selectedValueData == null && urlDataKey != null) ? dropdownData[urlDataKey] : selectedValueData;
                     selectedValueData = (selectedValueData == null && cookieDataKey != null) ? dropdownData[cookieDataKey] : selectedValueData;
-                    selectedValueData = (selectedValueData == null) ? dropdownData[0] : selectedValueData;
+                    selectedValueData = (selectedValueData == null) ? dropdownData[defaultValueIndex] : selectedValueData;
 
                     dropdownElement.data('contrailDropdown').text(selectedValueData.name);
                     if(dropdownOptions.preSelectCB != null && typeof(dropdownOptions.preSelectCB) == 'function') {


### PR DESCRIPTION
- Added defaultValueIndex option inside BreadcrumbDropdownView to specify the index of option to be selected when there is no url and cookie value.
- Added defaultValueIndex to 1 for MN List pages to avoid performance hit at the backend.

Change-Id: I7d6d427c94adf79a6f9e17a01b2bae7d18e6f4bb