### PR TITLE
Fixed Search issue on Network Monitoring

### DIFF
--- a/webroot/common/ui/css/contrail.graph.css
+++ b/webroot/common/ui/css/contrail.graph.css
@@ -180,12 +180,13 @@
 
 /* graph control panel */
 .graph-search-control-panel-expanded-container {
-    right: 33px;
+    right: 35px;
     width: 200px;
-    top: 190px;
-    height: 30px;
+    top: 195px;
+    height: 32px;
 }
 .graph-control-panel-search-dropdown {
     width: 100%;
     padding: 1px 2px;
+    border: none;
 }


### PR DESCRIPTION
Replaced .hide class with .hidden as .hide is depracated for Bootstrap 3.0+

Change-Id: Idae6ba3a1dbb309c9769e5bb994f60745e6f9e48
Closes-Bug: #1636985.